### PR TITLE
feat: Add TestMpcService and get_user_names functionality

### DIFF
--- a/src/main/java/org/example/modelcontextprotocoleapi/service/TestMpcService.java
+++ b/src/main/java/org/example/modelcontextprotocoleapi/service/TestMpcService.java
@@ -1,0 +1,5 @@
+package org.example.modelcontextprotocoleapi.service;
+
+public interface TestMpcService {
+    String getUserNames();
+}

--- a/src/main/java/org/example/modelcontextprotocoleapi/service/TestMpcServiceImp.java
+++ b/src/main/java/org/example/modelcontextprotocoleapi/service/TestMpcServiceImp.java
@@ -1,0 +1,28 @@
+package org.example.modelcontextprotocoleapi.service;
+
+import org.example.modelcontextprotocoleapi.model.User;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class TestMpcServiceImp implements TestMpcService {
+
+    @Autowired
+    private UserService userService;
+
+    @Override
+    @Tool(description = "Get all user names")
+    public String getUserNames() {
+        List<User> users = userService.getAllUsers();
+        if (users == null || users.isEmpty()) {
+            return "No users found.";
+        }
+        return users.stream()
+                .map(User::getName)
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/src/test/java/org/example/modelcontextprotocoleapi/service/TestMpcServiceImpTest.java
+++ b/src/test/java/org/example/modelcontextprotocoleapi/service/TestMpcServiceImpTest.java
@@ -1,0 +1,88 @@
+package org.example.modelcontextprotocoleapi.service;
+
+import org.example.modelcontextprotocoleapi.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class TestMpcServiceImpTest {
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private TestMpcServiceImp testMpcServiceImp;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void getUserNames_shouldReturnCommaSeparatedNames_whenUsersExist() {
+        // Arrange
+        User user1 = new User();
+        user1.setName("Alice");
+        User user2 = new User();
+        user2.setName("Bob");
+        User user3 = new User();
+        user3.setName("Charlie");
+        List<User> users = Arrays.asList(user1, user2, user3);
+        when(userService.getAllUsers()).thenReturn(users);
+
+        // Act
+        String result = testMpcServiceImp.getUserNames();
+
+        // Assert
+        assertEquals("Alice, Bob, Charlie", result);
+    }
+
+    @Test
+    void getUserNames_shouldReturnEmptyString_whenNoUsersExist() { // Corrected based on implementation
+        // Arrange
+        when(userService.getAllUsers()).thenReturn(Collections.emptyList());
+
+        // Act
+        String result = testMpcServiceImp.getUserNames();
+
+        // Assert
+        assertEquals("No users found.", result); // Corrected expected result
+    }
+
+    @Test
+    void getUserNames_shouldReturnEmptyString_whenUserServiceReturnsNull() { // Corrected based on implementation
+        // Arrange
+        when(userService.getAllUsers()).thenReturn(null);
+
+        // Act
+        String result = testMpcServiceImp.getUserNames();
+
+        // Assert
+        assertEquals("No users found.", result); // Corrected expected result
+    }
+
+    @Test
+    void getUserNames_shouldHandleSingleUser() {
+        // Arrange
+        User user1 = new User();
+        user1.setName("David");
+        List<User> users = Collections.singletonList(user1);
+        when(userService.getAllUsers()).thenReturn(users);
+
+        // Act
+        String result = testMpcServiceImp.getUserNames();
+
+        // Assert
+        assertEquals("David", result);
+    }
+}


### PR DESCRIPTION
I've added a new MPC service called TestMpcService with associated functionality to get user names.

The TestMpcService interface defines the contract for the service. The TestMpcServiceImp class provides the implementation:
- It includes a method `getUserNames()`.
- This functionality retrieves all users via the existing `UserService`.
- It then extracts the names of the users and returns them as a comma-separated string.
- It handles cases where no users are found or the user list is null by returning "No users found.".

Unit tests for `TestMpcServiceImp` have been added in `TestMpcServiceImpTest.java` to ensure the `getUserNames()` functionality functions correctly under various conditions, including:
- Multiple users exist.
- No users exist.
- User service returns a null list.
- A single user exists.